### PR TITLE
Allow no hash option

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,15 @@ This will import `fontcustom.css` into your stylesheet so that you can use the f
 
 The font files will be searched in your project's `images_path` and be written to the `css_path`.
 
+## Disabling File name hashes
+
+You can choose to disable file name hashes, if you're already using an asset pipeline that handles this for you : 
+Use the `no_fontcustom_hash` compass option in `config.rb`
+
+    compass_config do |config|
+    	config.no_fontcustom_hash = true
+    end
+
 ## Contributing
 
 1. Fork it

--- a/lib/compass/fontcustom/font_importer.rb
+++ b/lib/compass/fontcustom/font_importer.rb
@@ -1,5 +1,9 @@
 require 'fontcustom/generator'
 
+Compass::Configuration.add_configuration_property(:no_fontcustom_hash, "disables fontcustom file name hashing") do
+  false
+end
+
 module Compass
   module Fontcustom
 

--- a/test/unit/font_importer_test.rb
+++ b/test/unit/font_importer_test.rb
@@ -47,4 +47,25 @@ class FontImporterTest < Test::Unit::TestCase
     assert css =~ %r{.icon-d}
   end
 
+  it "should skip file name hashes if option is set" do
+    fontname = 'myfont'
+
+    Compass.configuration.no_fontcustom_hash = true
+
+    css = render <<-SCSS
+      @import "#{fontname}/*.svg";
+    SCSS
+
+    assert File.exists? File.join(Compass.configuration.css_path, 'fontcustom.css')
+    assert File.exists? File.join(Compass.configuration.css_path, 'fontcustom-ie7.css')
+    assert File.exists? File.join(Compass.configuration.css_path, 'myfont.eot')
+    assert File.exists? File.join(Compass.configuration.css_path, 'myfont.svg')
+    assert File.exists? File.join(Compass.configuration.css_path, 'myfont.ttf')
+    assert File.exists? File.join(Compass.configuration.css_path, 'myfont.woff')
+
+
+    assert css =~ %r{.icon-c}
+    assert css =~ %r{.icon-d}
+  end
+
 end


### PR DESCRIPTION
Adds an option to disable file name hashing.

Better when using an asset pipeline.

Tested.
