### PR TITLE
Make compass-fontcustom take proper filename for styles.

### DIFF
--- a/lib/compass/fontcustom.rb
+++ b/lib/compass/fontcustom.rb
@@ -26,6 +26,11 @@ module Compass
       {}
     end
 
+    Compass::Configuration.add_configuration_property(:fontcustom_discard_manifest,
+      'Remove manifest each time after fonts are compiled') do
+      false
+    end
+
     Sass.load_paths << FontImporter.new
   end
 end

--- a/lib/compass/fontcustom.rb
+++ b/lib/compass/fontcustom.rb
@@ -4,6 +4,7 @@ require "compass/fontcustom/compass"
 require "compass/fontcustom/sass_extensions"
 require "compass/fontcustom/glyph_map"
 require "compass/fontcustom/font_importer"
+require "compass/fontcustom/patches"
 
 module Compass
 	# This module registers the gem as a Compass framework source,
@@ -11,10 +12,6 @@ module Compass
   module Fontcustom
     base_directory  = File.expand_path('../../../', __FILE__)
     Compass::Frameworks.register('fontcustom', :path => base_directory)
-
-    Compass::Configuration.add_configuration_property(:fontcustom_hash, "enables/disables fontcustom file name hashing") do
-      true
-    end
 
     Compass::Configuration.add_configuration_property(:fontcustom_input_paths, "Array of paths where to search for SVG files to build custom fonts from") do
       if defined? Rails
@@ -24,8 +21,9 @@ module Compass
       end
     end
 
-    Compass::Configuration.add_configuration_property(:fontcustom_fonts_path, "Path to put generated font files in") do
-      Compass.configuration.fonts_path.to_s
+    Compass::Configuration.add_configuration_property(:fontcustom_options,
+      'Options passed to fontcustom when generating fonts') do
+      {}
     end
 
     Sass.load_paths << FontImporter.new

--- a/lib/compass/fontcustom/glyph_map.rb
+++ b/lib/compass/fontcustom/glyph_map.rb
@@ -44,7 +44,7 @@ module Compass
           :input     => path,
           :output    => output_dir,
           :font_name => @name,
-          :no_hash   => !Compass.configuration.fontcustom_hash,
+          :no_hash   => !with_hash?,
           :quiet     => true,
           :fonts     => []
         )
@@ -52,8 +52,13 @@ module Compass
       end
 
       def filename
-        file = glob.first
-        File.basename file, File.extname(file)
+        if with_hash?
+          glob = File.join(output_dir, "#{self.name}_#{'[0-9a-f]' * 32}.*")
+          file = Dir[glob].first
+          File.basename file, File.extname(file)
+        else
+          self.name
+        end
       end
 
       def output_dir
@@ -64,13 +69,11 @@ module Compass
         @name.to_s
       end
 
-      protected
+    protected
 
-        def glob
-          glob = File.join output_dir, "#{self.name}*"
-          Dir[glob]
-        end
-
+      def with_hash?
+        Compass.configuration.fontcustom_hash
+      end
     end
   end
 end

--- a/lib/compass/fontcustom/glyph_map.rb
+++ b/lib/compass/fontcustom/glyph_map.rb
@@ -49,7 +49,11 @@ module Compass
       end
 
       def fonts
-        @fontcustom.manifest.get(:fonts) if @fontcustom
+        if @fontcustom
+          @fontcustom.manifest.get(:fonts).each_with_object({}) do |font, result|
+            result[File.extname(font)[1..-1].to_sym] = font
+          end
+        end
       end
 
       def to_s

--- a/lib/compass/fontcustom/glyph_map.rb
+++ b/lib/compass/fontcustom/glyph_map.rb
@@ -39,40 +39,20 @@ module Compass
 
       # Starts the Fontcustom font generator to write font files to disk.
       def generate
-        args = self.class.config.generator_options || {}
-        args.merge!(
-          :input     => path,
-          :output    => output_dir,
-          :font_name => @name,
-          :no_hash   => !with_hash?,
-          :quiet     => true,
-          :fonts     => []
-        )
-        ::Fontcustom::Base.new(args).compile
+        args = (self.class.config.generator_options || {}).
+          merge(output: Compass.configuration.fonts_path.to_s, quiet: true, fonts: []).
+          merge(Compass.configuration.fontcustom_options).
+          merge(font_name: @name, input: path)
+        @fontcustom = ::Fontcustom::Base.new(args)
+        @fontcustom.compile
       end
 
-      def filename
-        if with_hash?
-          glob = File.join(output_dir, "#{self.name}_#{'[0-9a-f]' * 32}.*")
-          file = Dir[glob].first
-          File.basename file, File.extname(file)
-        else
-          self.name
-        end
-      end
-
-      def output_dir
-        Compass.configuration.fontcustom_fonts_path
+      def fonts
+        @fontcustom.manifest.get(:fonts) if @fontcustom
       end
 
       def to_s
         @name.to_s
-      end
-
-    protected
-
-      def with_hash?
-        Compass.configuration.fontcustom_hash
       end
     end
   end

--- a/lib/compass/fontcustom/glyph_map.rb
+++ b/lib/compass/fontcustom/glyph_map.rb
@@ -45,6 +45,7 @@ module Compass
           merge(font_name: @name, input: path)
         @fontcustom = ::Fontcustom::Base.new(args)
         @fontcustom.compile
+        File.delete(@fontcustom.manifest.manifest) if Compass.configuration.fontcustom_discard_manifest
       end
 
       def fonts

--- a/lib/compass/fontcustom/patches.rb
+++ b/lib/compass/fontcustom/patches.rb
@@ -1,0 +1,3 @@
+class Fontcustom::Base
+   attr_accessor :manifest
+end

--- a/lib/compass/fontcustom/sass_extensions.rb
+++ b/lib/compass/fontcustom/sass_extensions.rb
@@ -43,10 +43,13 @@ module Compass
           map.generate
           src = []
 
-          map.fonts.each do |font|
-            options = FONT_TYPE_OPTIONS[File.extname(font)[1..-1].to_sym]
-            url = glyph_font_type_url("#{font}#{options[:postfix]}" % {font_name: map.name})
-            src << "#{url} format('#{options[:format]}')"
+          fonts = map.fonts
+
+          FONT_TYPE_OPTIONS.each do |font_type, options|
+            if font = fonts[font_type]
+              url = glyph_font_type_url("#{font}#{options[:postfix]}" % {font_name: map.name})
+              src << "#{url} format('#{options[:format]}')"
+            end
           end
           Sass::Script::String.new src.join ", "
         end


### PR DESCRIPTION
Fixes #14 
The problem was that taking files just by font name is unreliable, as it can randomly take fontname_preview file or whatever lies in the same folder. So I chose a glob path, which is not likely to miss.
